### PR TITLE
exclude tests from acceptable identifiers

### DIFF
--- a/src/extractUnusedExports.js
+++ b/src/extractUnusedExports.js
@@ -5,10 +5,12 @@ export default function extractUnusedExports(
   importedIdentifiers,
   importedIdentifiersTest
 ) {
+  const testPaths = new Set(
+    importedIdentifiersTest.map(identifier => identifier.sourcePath)
+  );
+
   const identifierIsNotATest = importedIdentifier =>
-    !importedIdentifiersTest
-      .map(identifier => identifier.sourcePath)
-      .includes(importedIdentifier.sourcePath);
+    !testPaths.has(importedIdentifier.sourcePath);
 
   // Build map for quick lookup, where key is combined using path and name
   const importsByKey = importedIdentifiers

--- a/src/extractUnusedExports.js
+++ b/src/extractUnusedExports.js
@@ -2,18 +2,26 @@ import lodash from 'lodash';
 
 export default function extractUnusedExports(
   exportedNames,
-  importedIdentifiers
+  importedIdentifiers,
+  importedIdentifiersTest
 ) {
-  // Build map for quick lookup, where key is combined using path and name
-  const importsByKey = importedIdentifiers.reduce((map, imp) => {
-    lodash.forEach(imp.imports, (importedNames, importedFrom) => {
-      importedNames.forEach(importedName => {
-        map.set(`${importedFrom}:${importedName}`, true);
-      });
-    });
+  const identifierIsNotATest = importedIdentifier =>
+    !importedIdentifiersTest
+      .map(identifier => identifier.sourcePath)
+      .includes(importedIdentifier.sourcePath);
 
-    return map;
-  }, new Map());
+  // Build map for quick lookup, where key is combined using path and name
+  const importsByKey = importedIdentifiers
+    .filter(identifierIsNotATest)
+    .reduce((map, imp) => {
+      lodash.forEach(imp.imports, (importedNames, importedFrom) => {
+        importedNames.forEach(importedName => {
+          map.set(`${importedFrom}:${importedName}`, true);
+        });
+      });
+
+      return map;
+    }, new Map());
 
   return exportedNames.reduce((accumulator, exported) => {
     const { relativePath, sourcePath } = exported;

--- a/src/tests/extractUnusedExports.spec.js
+++ b/src/tests/extractUnusedExports.spec.js
@@ -20,22 +20,76 @@ describe('extractUnusedExports', () => {
 
       const importedNames = [
         {
+          sourcePath: '/project/src/fileA',
           relativePath: 'src/fileA',
           imports: { [relativePath]: ['ArrowLeft'] }
         },
         {
+          sourcePath: '/project/src/fileB',
           relativePath: 'src/fileB',
           imports: { [relativePath]: ['ArrowRight'] }
         }
       ];
 
-      const result = extractUnusedExports(exportedNames, importedNames);
+      const result = extractUnusedExports(exportedNames, importedNames, []);
 
       expect(result).toEqual([
         {
           relativePath,
           sourcePath,
           unusedExports: [{ name: 'ArrowCenter' }]
+        }
+      ]);
+    });
+
+    it('includes unused exports from tests', () => {
+      const sourcePath = '/project/src/Arrows';
+      const relativePath = 'src/Arrows';
+
+      const exportedNames = [
+        {
+          sourcePath,
+          relativePath,
+          exports: [
+            { name: 'ArrowLeft' },
+            { name: 'ArrowCenter' },
+            { name: 'ArrowRight' }
+          ]
+        }
+      ];
+
+      const importedNames = [
+        {
+          sourcePath: '/project/src/fileA',
+          relativePath: 'src/fileA',
+          imports: { [relativePath]: ['ArrowLeft'] }
+        },
+        {
+          sourcePath: '/project/tests/Arrows/fileB',
+          relativePath: 'tests/Arrows/fileB',
+          imports: { [relativePath]: ['ArrowRight'] }
+        }
+      ];
+
+      const importNamesTest = [
+        {
+          sourcePath: '/project/tests/Arrows/fileB',
+          relativePath: 'tests/Arrows/fileB',
+          imports: { [relativePath]: ['ArrowRight'] }
+        }
+      ];
+
+      const result = extractUnusedExports(
+        exportedNames,
+        importedNames,
+        importNamesTest
+      );
+
+      expect(result).toEqual([
+        {
+          relativePath,
+          sourcePath,
+          unusedExports: [{ name: 'ArrowCenter' }, { name: 'ArrowRight' }]
         }
       ]);
     });


### PR DESCRIPTION
Apparently the `testPath` configuration is not used.

The cli [does call `extractUnusedExports` with a third parameter for test paths](https://github.com/devbridge/js-unused-exports/blob/7f21b086c157aa5d03459fca4d53e3625ca08194/src/cli.js#L36) but [the function definition](https://github.com/devbridge/js-unused-exports/blob/350c6b3ec5ba1cc6b6d13eb3a759750e0e354396/src/extractUnusedExports.js#L3-L6) does not use it.

This PR fixes this issue.