### PR TITLE
Ass possibility to add ignoreExportPatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Options:
   // Import patterns to ignore
   ignoreImportPatterns: [ '(png|gif|jpg|jpeg|css|scss)$' ],
 
+  // Export patterns to ignore
+  ignoreExportPatterns: [ '(stories)' ],
+
   // If you use alias in you codebase you can specify them here, e.g.:
   aliases: {
     components: 'src/components'

--- a/src/getExports.js
+++ b/src/getExports.js
@@ -4,12 +4,21 @@ import { parse } from '@babel/parser';
 import { toRelativePath } from './utils';
 
 export default function getExports(sourcePaths, ctx) {
-  return sourcePaths.map(sourcePath => {
+  const result = [];
+
+  for (const sourcePath of sourcePaths) {
     const source = fs.readFileSync(sourcePath, 'utf8');
     const exportData = getExportData(source, sourcePath, ctx);
 
-    return exportData;
-  });
+    var ignoreExportPatterns = ctx.config.ignoreExportPatterns;
+    if (
+      !ignoreExportPatterns ||
+      ignoreExportPatterns.every((pattern) => !RegExp(pattern).test(sourcePath))
+    ) {
+      result.push(exportData);
+    }
+  }
+  return result;
 }
 
 function getExportData(source, sourcePath, ctx) {

--- a/src/getExports.js
+++ b/src/getExports.js
@@ -83,15 +83,15 @@ function getExportName(node) {
 
   switch (type) {
     case 'VariableDeclaration':
-      return node.declaration.declarations.map((declaration) => ({
+      return node.declaration.declarations.map(declaration => ({
         name: declaration.id.name,
-        loc: node.loc,
+        loc: node.loc
       }));
     case 'FunctionDeclaration':
     case 'ClassDeclaration':
       return {
         name: node.declaration.id.name,
-        loc: node.loc,
+        loc: node.loc
       };
     default:
       throw new Error(`Unknow declaration type: ${type}`);

--- a/src/getExports.js
+++ b/src/getExports.js
@@ -4,7 +4,7 @@ import { parse } from '@babel/parser';
 import { toRelativePath } from './utils';
 
 export default function getExports(sourcePaths, ctx) {
-  return sourcePaths.reduce(function (result, sourcePath) {
+  return sourcePaths.reduce((result, sourcePath) => {
     const source = fs.readFileSync(sourcePath, 'utf8');
     const exportData = getExportData(source, sourcePath, ctx);
 

--- a/src/getExports.js
+++ b/src/getExports.js
@@ -4,21 +4,20 @@ import { parse } from '@babel/parser';
 import { toRelativePath } from './utils';
 
 export default function getExports(sourcePaths, ctx) {
-  const result = [];
-
-  for (const sourcePath of sourcePaths) {
+  return sourcePaths.reduce(function (result, sourcePath) {
     const source = fs.readFileSync(sourcePath, 'utf8');
     const exportData = getExportData(source, sourcePath, ctx);
 
-    var ignoreExportPatterns = ctx.config.ignoreExportPatterns;
+    const ignoreExportPatterns = ctx.config.ignoreExportPatterns;
     if (
       !ignoreExportPatterns ||
       ignoreExportPatterns.every((pattern) => !RegExp(pattern).test(sourcePath))
     ) {
       result.push(exportData);
     }
-  }
-  return result;
+
+    return result;
+  }, []);
 }
 
 function getExportData(source, sourcePath, ctx) {
@@ -84,15 +83,15 @@ function getExportName(node) {
 
   switch (type) {
     case 'VariableDeclaration':
-      return node.declaration.declarations.map(declaration => ({
+      return node.declaration.declarations.map((declaration) => ({
         name: declaration.id.name,
-        loc: node.loc
+        loc: node.loc,
       }));
     case 'FunctionDeclaration':
     case 'ClassDeclaration':
       return {
         name: node.declaration.id.name,
-        loc: node.loc
+        loc: node.loc,
       };
     default:
       throw new Error(`Unknow declaration type: ${type}`);


### PR DESCRIPTION
Similarly to how it is possible to ignore some of the files for import by the pattern provide din the config, this will allow to ignore some of the files, that matched pattern for export information.
