### PR TITLE
Fixed failing tests on Windows 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import glob from 'glob';
 
 /**
@@ -12,7 +13,9 @@ export function getSourcePaths(globPatterns, config) {
     absolute: true,
   };
 
-  return globPatterns.flatMap((globPattern) => glob.sync(globPattern, options));
+  return globPatterns
+    .flatMap((globPattern) => glob.sync(globPattern, options))
+    .map((sourcePath) => path.normalize(sourcePath));
 }
 
 // Lifted from lodash

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -7,7 +7,7 @@ function testUnusedExports(unusedExports, expectations) {
   Object.entries(expectations).forEach(
     ([relativePath, expectedUnusedNames]) => {
       const unusedExport = unusedExports.find(({ sourcePath }) =>
-        sourcePath.endsWith(relativePath)
+        sourcePath.endsWith(path.normalize(relativePath))
       );
 
       if (!unusedExport) {


### PR DESCRIPTION
Added `path.normalize` to getSourcePaths to fix issues with windows paths

![image](https://user-images.githubusercontent.com/506895/95957804-7b847800-0e00-11eb-9891-5239415c76a9.png)
